### PR TITLE
Including prior information from survival meta-analysis

### DIFF
--- a/R/GPeafowlIPM_mainModel.R
+++ b/R/GPeafowlIPM_mainModel.R
@@ -54,6 +54,14 @@ ny.sim <- 51 # Number of years to simulate after the data collection
 
 source("R/ReproductionDataPrep.R")
 
+# Prior information from survival meta-analysis
+metaSurv.mean <- 0.729
+metaSurv.se <- 0.0945
+metaSurv.n <- 11
+
+# Survival difference between subadult and life-stages
+saSurv.diff <- 0.1 # Survial of subadults = 10% lower than adult
+
 ## Arrange constants
 
 GP.IPMconstants <- list(Tmax = ny.data + ny.sim, 
@@ -65,7 +73,10 @@ GP.IPMconstants <- list(Tmax = ny.data + ny.sim,
                         xmax = xmax,
                         ymax = ymax,
                         Year_BS = Year_BS,
-                        cmax = cmax
+                        cmax = cmax,
+                        metaSurv.mean = metaSurv.mean,
+                        metaSurv.se = metaSurv.se,
+                        saSurv.diff = saSurv.diff,
                         
 )
 
@@ -100,16 +111,16 @@ GP.IPMcode <- nimbleCode({
   
   ## Chicks and juveniles
   
-  sF_NB[1] ~ dunif(0.50, 0.60) 
-  sF_BN[1] ~ dunif(0.50, 0.60) 
+  sF_NB[1] ~ dunif(0.50, 0.60)
+  sF_BN[1] ~ dunif(0.50, 0.60)
   
   sM_NB[1] <- sF_NB[1] 
   sM_BN[1] <- sF_BN[1]  
   
   ## Adults (no sex difference)
   
-  s_yr_sa ~ dunif(0.80, 0.90) 
-  s_yr_ad ~ dunif(0.80, 0.90)  
+  s_yr_sa ~ T(dnorm(mean = metaSurv.mean - saSurv.diff, sd = metaSurv.se), 0, 1)
+  s_yr_ad ~ T(dnorm(mean = metaSurv.mean, sd = metaSurv.se), 0, 1)  
   
   s_yr_saF <- s_yr_sa
   s_yr_saM <- s_yr_sa 


### PR DESCRIPTION
We can use estimates from Matt's meta-analysis as prior information for adult (and subadult) survival. 
The mean and standard error from the meta-analysis correspond to adult birds, so we specify a normal prior accordingly. NOTE that for now, I am using the standard error from the meta-analysis as the standard deviation for specifying the prior. That for two reasons: I am not sure about the "sample size" here and assuming sample size = number of studies (= 11), the uncertainty in the prior becomes very large. But Matt should do a sanity check of that. 

For subadults, we can use the same prior, potentially with an adjustment. I made a variable for that purpose and set it to 0.1, meaning we assume that subadult survival is 0.1 (10%) less than adult survival. 

I also note that we still use rather narrow uniform priors for the chick and juvenile half-year survival. From what I gathered, there is not enough evidence in the literature there to make inference. However, for this one in particular, the count data should provide some information. We should check what the posteriors look like (and adjust priors if necessary). 